### PR TITLE
updated container to generate ssl certificate

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,12 +2,10 @@ FROM edoburu/pgbouncer:latest
 
 USER root
 
-# Install HAProxy and Python
-RUN apk add --no-cache haproxy python3 py3-requests
+# Install HAProxy, Python, and OpenSSL
+RUN apk add --no-cache haproxy python3 py3-requests openssl
 
-# Certificates and PgBouncer config
-COPY /pgbouncer/server.crt /etc/pgbouncer/server.crt
-COPY /pgbouncer/server.key /etc/pgbouncer/server.key
+# PgBouncer config
 COPY /pgbouncer/userlist.txt /etc/pgbouncer/userlist.txt
 COPY /pgbouncer/pgbouncer.ini.tmpl /scripts/app/pgbouncer.ini.tmpl
 

--- a/app/pgbouncer/pgbouncer_manager.py
+++ b/app/pgbouncer/pgbouncer_manager.py
@@ -17,18 +17,18 @@ class PgBouncerManager(ProcessManager):
         if os.path.exists(self.cert_path) and os.path.exists(self.key_path):
             return
 
-        print("Generating self-signed certificates...")
+        print("Generating self-signed certificate...")
         # Generate private key
         subprocess.run([
             "openssl", "genrsa", "-out", self.key_path, "2048"
-        ], check=True)
+        ], check=True, capture_output=True)
         
         # Generate CSR
         subprocess.run([
             "openssl", "req", "-new", "-key", self.key_path,
             "-out", "/tmp/server.csr",
-            "-subj", "/CN=localhost"
-        ], check=True)
+            "-subj", "/CN=localhost/O=DO NOT TRUST/OU=Neon Local self-signed cert"
+        ], check=True, capture_output=True)
         
         # Generate self-signed certificate
         subprocess.run([

--- a/app/pgbouncer/pgbouncer_manager.py
+++ b/app/pgbouncer/pgbouncer_manager.py
@@ -1,4 +1,3 @@
-
 import os
 import json
 import subprocess
@@ -10,8 +9,44 @@ class PgBouncerManager(ProcessManager):
         super().__init__()
         self.pgbouncer_process = None
         self.neon_api = NeonAPI()
+        self.cert_path = "/etc/pgbouncer/server.crt"
+        self.key_path = "/etc/pgbouncer/server.key"
+
+    def _generate_certificates(self):
+        """Generate self-signed certificates if they don't exist."""
+        if os.path.exists(self.cert_path) and os.path.exists(self.key_path):
+            return
+
+        print("Generating self-signed certificates...")
+        # Generate private key
+        subprocess.run([
+            "openssl", "genrsa", "-out", self.key_path, "2048"
+        ], check=True)
+        
+        # Generate CSR
+        subprocess.run([
+            "openssl", "req", "-new", "-key", self.key_path,
+            "-out", "/tmp/server.csr",
+            "-subj", "/CN=localhost"
+        ], check=True)
+        
+        # Generate self-signed certificate
+        subprocess.run([
+            "openssl", "x509", "-req", "-days", "365",
+            "-in", "/tmp/server.csr",
+            "-signkey", self.key_path,
+            "-out", self.cert_path
+        ], check=True)
+        
+        # Set proper permissions
+        os.chmod(self.key_path, 0o600)
+        os.chmod(self.cert_path, 0o644)
+        
+        # Clean up CSR
+        os.remove("/tmp/server.csr")
 
     def prepare_config(self):
+        self._generate_certificates()
         state = self._get_neon_branch()
         current_branch = self._get_git_branch()
         parent = os.getenv("PARENT_BRANCH_ID")


### PR DESCRIPTION
Removed static ssl cert from the container and made it so that the container generates an ssl certificate on startup, so that every neon_local container has a unique certificate used by the pgbouncer client. If the container is restarted, the previously created ssl cert will be re-used instead of regenerated. 