### PR TITLE
Fixed bug caused by branch having multiple databases and enabled connect to existing branch functionality

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -25,6 +25,9 @@ RUN touch /scripts/app/__init__.py
 # Environment
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/scripts
+ENV NEON_PROJECT_ID=""
+ENV BRANCH_ID=""
+ENV DELETE_BRANCH=true
 
 # Create and set permissions for logs
 RUN touch /var/log/pgbouncer.log \

--- a/app/haproxy/haproxy_manager.py
+++ b/app/haproxy/haproxy_manager.py
@@ -15,6 +15,8 @@ class HAProxyManager(ProcessManager):
             state = self._get_neon_branch()
             current_branch = self._get_git_branch()
             parent = os.getenv("PARENT_BRANCH_ID")
+            if parent == "":
+                parent = None
             params, updated_state = self.neon_api.fetch_or_create_branch(state, current_branch, parent)
             self._write_neon_branch(updated_state)
         else:

--- a/app/haproxy/haproxy_manager.py
+++ b/app/haproxy/haproxy_manager.py
@@ -11,12 +11,16 @@ class HAProxyManager(ProcessManager):
         self.neon_api = NeonAPI()
 
     def prepare_config(self):
-        state = self._get_neon_branch()
-        current_branch = self._get_git_branch()
-        parent = os.getenv("PARENT_BRANCH_ID")
-        params, updated_state = self.neon_api.fetch_or_create_branch(state, current_branch, parent)
+        if self.manage_branches:
+            state = self._get_neon_branch()
+            current_branch = self._get_git_branch()
+            parent = os.getenv("PARENT_BRANCH_ID")
+            params, updated_state = self.neon_api.fetch_or_create_branch(state, current_branch, parent)
+            self._write_neon_branch(updated_state)
+        else:
+            params = self.neon_api.get_branch_connection_info(self.project_id, self.branch_id)
+            
         self._write_haproxy_config(params)
-        self._write_neon_branch(updated_state)
 
     def start_process(self):
         self.prepare_config()

--- a/app/neon.py
+++ b/app/neon.py
@@ -160,6 +160,8 @@ class NeonAPI:
                 payload = {"annotation_value": {"neon_local": "true"}, "endpoints": [{"type": "read_write"}], "branch": {"parent_id": parent_branch_id}}
             else:
                 payload = {"annotation_value": {"neon_local": "true"}, "endpoints": [{"type": "read_write"}]}
+            if self.vscode:
+                payload["annotation_value"]["vscode": "true"]
             response = requests.post(f"{API_URL}/projects/{self.project_id}/branches",
                                      headers=self._headers(), json=payload)
             response.raise_for_status()

--- a/app/neon.py
+++ b/app/neon.py
@@ -131,7 +131,13 @@ class NeonAPI:
         params = state.get(current_branch)
         if params:
             try:
-                requests.get(f"{API_URL}/projects/{self.project_id}/branches/{params['branch_id']}",
+                # Handle both old and new state formats
+                branch_id = params.get("branch_id")
+                if not branch_id:
+                    print("No branch_id found in state, skipping cleanup")
+                    return state
+                    
+                requests.get(f"{API_URL}/projects/{self.project_id}/branches/{branch_id}",
                              headers=self._headers()).raise_for_status()
             except:
                 print("Branch not found at Neon.")
@@ -139,7 +145,7 @@ class NeonAPI:
 
             if params:
                 response = requests.delete(
-                    f"{API_URL}/projects/{self.project_id}/branches/{params['branch_id']}",
+                    f"{API_URL}/projects/{self.project_id}/branches/{branch_id}",
                     headers=self._headers())
                 print(response)
                 response.raise_for_status()
@@ -181,6 +187,10 @@ class NeonAPI:
 
         # Get connection info for the branch
         connection_info = self.get_branch_connection_info(self.project_id, branch_id)
+        
+        # Add branch_id to each connection info object
+        for info in connection_info:
+            info["branch_id"] = branch_id
         
         # Store branch ID in state
         if current_branch:

--- a/app/pgbouncer/pgbouncer.ini.tmpl
+++ b/app/pgbouncer/pgbouncer.ini.tmpl
@@ -10,7 +10,9 @@ pool_mode = transaction
 max_client_conn = 100
 max_prepared_statements = 100
 default_pool_size = 20
-client_tls_sslmode = disable
+client_tls_sslmode = require
+client_tls_cert_file = /etc/pgbouncer/server.crt
+client_tls_key_file = /etc/pgbouncer/server.key
 
 server_tls_sslmode = verify-full
 log_connections = 1

--- a/app/pgbouncer/pgbouncer.ini.tmpl
+++ b/app/pgbouncer/pgbouncer.ini.tmpl
@@ -1,8 +1,8 @@
 [databases]
-*=user={role} password={password} host={host} port=5432 dbname={database}
+*=user={role} password={password} host={host} port=5432 dbname={database} 
 
 [pgbouncer]
-listen_addr = 0.0.0.0
+listen_addr = ::
 listen_port = 5432
 auth_type = md5
 auth_file = /etc/pgbouncer/userlist.txt
@@ -10,9 +10,8 @@ pool_mode = transaction
 max_client_conn = 100
 max_prepared_statements = 100
 default_pool_size = 20
-client_tls_sslmode = require
-client_tls_cert_file = /etc/pgbouncer/server.crt
-client_tls_key_file = /etc/pgbouncer/server.key
+client_tls_sslmode = disable
+
 server_tls_sslmode = verify-full
 log_connections = 1
 log_disconnections = 1

--- a/app/pgbouncer/pgbouncer.ini.tmpl
+++ b/app/pgbouncer/pgbouncer.ini.tmpl
@@ -2,7 +2,7 @@
 *=user={role} password={password} host={host} port=5432 dbname={database} 
 
 [pgbouncer]
-listen_addr = ::
+listen_addr = 0.0.0.0
 listen_port = 5432
 auth_type = md5
 auth_file = /etc/pgbouncer/userlist.txt

--- a/app/pgbouncer/pgbouncer_manager.py
+++ b/app/pgbouncer/pgbouncer_manager.py
@@ -48,35 +48,28 @@ class PgBouncerManager(ProcessManager):
     def prepare_config(self):
         self._generate_certificates()
         params = None
-        print(f"Debug: parent_branch_id={self.parent_branch_id}, branch_id={self.branch_id}")
         
         if self.parent_branch_id:
-            print("Debug: Using parent branch flow")
             state = self._get_neon_branch()
             current_branch = self._get_git_branch()
             parent = os.getenv("PARENT_BRANCH_ID")
             if parent == "":
                 parent = None
-            print(f"Debug: current_branch={current_branch}, parent={parent}")
             params, updated_state = self.neon_api.fetch_or_create_branch(state, current_branch, parent, self.vscode)
             self._write_neon_branch(updated_state)
         elif self.branch_id:
-            print(f"Debug: Using direct branch flow with branch_id={self.branch_id}")
             try:
                 params = self.neon_api.get_branch_connection_info(self.project_id, self.branch_id)
-                print(f"Debug: Got connection info: {params}")
             except Exception as e:
                 print(f"Debug: Error getting connection info: {str(e)}")
                 raise
         else:
-            print("Debug: No branch ID provided, creating new branch from main")
             state = self._get_neon_branch()
             current_branch = self._get_git_branch()
             params, updated_state = self.neon_api.fetch_or_create_branch(state, current_branch, vscode=self.vscode)
             self._write_neon_branch(updated_state)
         
         if params is None:
-            print("Debug: No parameters obtained from any flow")
             raise ValueError("Failed to get connection parameters")
             
         self._write_pgbouncer_config(params)

--- a/app/pgbouncer/pgbouncer_manager.py
+++ b/app/pgbouncer/pgbouncer_manager.py
@@ -11,16 +11,37 @@ class PgBouncerManager(ProcessManager):
         self.neon_api = NeonAPI()
 
     def prepare_config(self):
+        params = None
+        print(f"Debug: parent_branch_id={self.parent_branch_id}, branch_id={self.branch_id}")
+        
         if self.parent_branch_id:
+            print("Debug: Using parent branch flow")
             state = self._get_neon_branch()
             current_branch = self._get_git_branch()
             parent = os.getenv("PARENT_BRANCH_ID")
             if parent == "":
                 parent = None
-            params, updated_state = self.neon_api.fetch_or_create_branch(state, current_branch, parent)
+            print(f"Debug: current_branch={current_branch}, parent={parent}")
+            params, updated_state = self.neon_api.fetch_or_create_branch(state, current_branch, parent, self.vscode)
             self._write_neon_branch(updated_state)
         elif self.branch_id:
-            params = self.neon_api.get_branch_connection_info(self.project_id, self.branch_id)
+            print(f"Debug: Using direct branch flow with branch_id={self.branch_id}")
+            try:
+                params = self.neon_api.get_branch_connection_info(self.project_id, self.branch_id)
+                print(f"Debug: Got connection info: {params}")
+            except Exception as e:
+                print(f"Debug: Error getting connection info: {str(e)}")
+                raise
+        else:
+            print("Debug: No branch ID provided, creating new branch from main")
+            state = self._get_neon_branch()
+            current_branch = self._get_git_branch()
+            params, updated_state = self.neon_api.fetch_or_create_branch(state, current_branch, vscode=self.vscode)
+            self._write_neon_branch(updated_state)
+        
+        if params is None:
+            print("Debug: No parameters obtained from any flow")
+            raise ValueError("Failed to get connection parameters")
             
         self._write_pgbouncer_config(params)
 
@@ -42,9 +63,29 @@ class PgBouncerManager(ProcessManager):
                 self.pgbouncer_process.wait()
             self.pgbouncer_process = None
     
-    def _write_pgbouncer_config(self, params):
+    def _write_pgbouncer_config(self, databases):
         with open("/scripts/app/pgbouncer.ini.tmpl", "r") as file:
             template = file.read()
-        config = template.format(**params)
+        
+        # Split the template into sections
+        sections = template.split("[pgbouncer]")
+        databases_section = sections[0].strip()
+        pgbouncer_section = sections[1].strip()
+        
+        # Generate database entries for each database
+        database_entries = []
+        for db in databases:
+            entry = f"{db['database']}=user={db['user']} password={db['password']} host={db['host']} port=5432 dbname={db['database']}"
+            database_entries.append(entry)
+        
+        # Add wildcard entry pointing to the first database
+        if databases:
+            first_db = databases[0]
+            wildcard_entry = f"*=user={first_db['user']} password={first_db['password']} host={first_db['host']} port=5432 dbname={first_db['database']}"
+            database_entries.append(wildcard_entry)
+        
+        # Combine all sections
+        config = f"[databases]\n" + "\n".join(database_entries) + "\n\n[pgbouncer]\n" + pgbouncer_section
+        
         with open("/etc/pgbouncer/pgbouncer.ini", "w") as file:
             file.write(config)

--- a/app/pgbouncer/pgbouncer_manager.py
+++ b/app/pgbouncer/pgbouncer_manager.py
@@ -11,7 +11,7 @@ class PgBouncerManager(ProcessManager):
         self.neon_api = NeonAPI()
 
     def prepare_config(self):
-        if self.manage_branches:
+        if self.parent_branch_id:
             state = self._get_neon_branch()
             current_branch = self._get_git_branch()
             parent = os.getenv("PARENT_BRANCH_ID")
@@ -19,7 +19,7 @@ class PgBouncerManager(ProcessManager):
                 parent = None
             params, updated_state = self.neon_api.fetch_or_create_branch(state, current_branch, parent)
             self._write_neon_branch(updated_state)
-        else:
+        elif self.branch_id:
             params = self.neon_api.get_branch_connection_info(self.project_id, self.branch_id)
             
         self._write_pgbouncer_config(params)

--- a/app/pgbouncer/pgbouncer_manager.py
+++ b/app/pgbouncer/pgbouncer_manager.py
@@ -1,4 +1,3 @@
-
 import os
 import json
 import subprocess
@@ -12,12 +11,16 @@ class PgBouncerManager(ProcessManager):
         self.neon_api = NeonAPI()
 
     def prepare_config(self):
-        state = self._get_neon_branch()
-        current_branch = self._get_git_branch()
-        parent = os.getenv("PARENT_BRANCH_ID")
-        params, updated_state = self.neon_api.fetch_or_create_branch(state, current_branch, parent)
+        if self.manage_branches:
+            state = self._get_neon_branch()
+            current_branch = self._get_git_branch()
+            parent = os.getenv("PARENT_BRANCH_ID")
+            params, updated_state = self.neon_api.fetch_or_create_branch(state, current_branch, parent)
+            self._write_neon_branch(updated_state)
+        else:
+            params = self.neon_api.get_branch_connection_info(self.project_id, self.branch_id)
+            
         self._write_pgbouncer_config(params)
-        self._write_neon_branch(updated_state)
 
     def start_process(self):
         self.prepare_config()

--- a/app/pgbouncer/pgbouncer_manager.py
+++ b/app/pgbouncer/pgbouncer_manager.py
@@ -15,6 +15,8 @@ class PgBouncerManager(ProcessManager):
             state = self._get_neon_branch()
             current_branch = self._get_git_branch()
             parent = os.getenv("PARENT_BRANCH_ID")
+            if parent == "":
+                parent = None
             params, updated_state = self.neon_api.fetch_or_create_branch(state, current_branch, parent)
             self._write_neon_branch(updated_state)
         else:

--- a/app/process_manager.py
+++ b/app/process_manager.py
@@ -1,4 +1,3 @@
-
 import threading
 import hashlib
 import time
@@ -15,6 +14,9 @@ class ProcessManager:
         self.watcher_thread = None
         self.reloader_thread = None
         self.neon = NeonAPI()
+        self.project_id = os.getenv("NEON_PROJECT_ID")
+        self.branch_id = os.getenv("BRANCH_ID")
+        self.manage_branches = self.project_id is None or self.branch_id is None
 
     def calculate_file_hash(self, path):
         if not os.path.exists(path):
@@ -55,6 +57,9 @@ class ProcessManager:
         self.stop_process()
 
     def branch_cleanup(self):
+        if not self.manage_branches:
+            return
+            
         print("Running branch cleanup...")
         state = self._get_neon_branch()
         print("State")
@@ -83,6 +88,9 @@ class ProcessManager:
             return {}
 
     def _write_neon_branch(self, state):
+        if not self.manage_branches:
+            return
+            
         try:
             os.makedirs("/tmp/.neon_local", exist_ok=True)
             with open("/tmp/.neon_local/.branches", "w") as file:
@@ -101,7 +109,7 @@ class ProcessManager:
         self.start_process()
 
     def cleanup(self):
-        delete_branch = os.getenv("DELETE_BRANCH", "true").lower() == "true"
+        delete_branch = os.getenv("DELETE_BRANCH", "true").lower() == "true" and self.manage_branches
         if delete_branch:
             self.branch_cleanup()
         self.shutdown_event.set()

--- a/app/process_manager.py
+++ b/app/process_manager.py
@@ -16,6 +16,9 @@ class ProcessManager:
         self.neon = NeonAPI()
         self.project_id = os.getenv("NEON_PROJECT_ID")
         self.branch_id = os.getenv("BRANCH_ID")
+        # Treat empty string the same as None
+        if self.branch_id == "":
+            self.branch_id = None
         self.manage_branches = self.project_id is None or self.branch_id is None
 
     def calculate_file_hash(self, path):

--- a/app/process_manager.py
+++ b/app/process_manager.py
@@ -14,22 +14,24 @@ class ProcessManager:
         self.watcher_thread = None
         self.reloader_thread = None
         self.neon = NeonAPI()
+        
+        # Get and validate required environment variables
         self.project_id = os.getenv("NEON_PROJECT_ID")
+        if not self.project_id:
+            raise ValueError("NEON_PROJECT_ID environment variable is required")
+            
         self.branch_id = os.getenv("BRANCH_ID")
-        # Treat empty string the same as None
-        if self.branch_id == "":
-            self.branch_id = None
+        if not self.branch_id:
+            print("Warning: BRANCH_ID not set, will use parent branch flow")
+            
         self.parent_branch_id = os.getenv("PARENT_BRANCH_ID")
-        if self.parent_branch_id == "":
-            self.parent_branch_id = None
-        self.delete_branch = os.getenv("DELETE_BRANCH")
-        if self.delete_branch == "" or self.delete_branch == None:
-            self.delete_branch = True
-        self.vscode = os.getenv("VSCODE")
-        if self.vscode == "":
-            self.vscode = None
+        if not self.parent_branch_id:
+            print("Warning: PARENT_BRANCH_ID not set")
+            
+        self.delete_branch = os.getenv("DELETE_BRANCH", "true").lower() == "true"
+        self.vscode = os.getenv("VSCODE", "").lower() == "true"
         
-        
+        print(f"Debug: Initialized with project_id={self.project_id}, branch_id={self.branch_id}, parent_branch_id={self.parent_branch_id}")
 
     def calculate_file_hash(self, path):
         if not os.path.exists(path):

--- a/app/process_manager.py
+++ b/app/process_manager.py
@@ -19,7 +19,17 @@ class ProcessManager:
         # Treat empty string the same as None
         if self.branch_id == "":
             self.branch_id = None
-        self.manage_branches = self.project_id is None or self.branch_id is None
+        self.parent_branch_id = os.getenv("PARENT_BRANCH_ID")
+        if self.parent_branch_id == "":
+            self.parent_branch_id = None
+        self.delete_branch = os.getenv("DELETE_BRANCH")
+        if self.delete_branch == "" or self.delete_branch == None:
+            self.delete_branch = True
+        self.vscode = os.getenv("VSCODE")
+        if self.vscode == "":
+            self.vscode = None
+        
+        
 
     def calculate_file_hash(self, path):
         if not os.path.exists(path):
@@ -60,7 +70,7 @@ class ProcessManager:
         self.stop_process()
 
     def branch_cleanup(self):
-        if not self.manage_branches:
+        if not self.delete_branch:
             return
             
         print("Running branch cleanup...")
@@ -91,9 +101,6 @@ class ProcessManager:
             return {}
 
     def _write_neon_branch(self, state):
-        if not self.manage_branches:
-            return
-            
         try:
             os.makedirs("/tmp/.neon_local", exist_ok=True)
             with open("/tmp/.neon_local/.branches", "w") as file:
@@ -112,8 +119,7 @@ class ProcessManager:
         self.start_process()
 
     def cleanup(self):
-        delete_branch = os.getenv("DELETE_BRANCH", "true").lower() == "true" and self.manage_branches
-        if delete_branch:
+        if self.delete_branch:
             self.branch_cleanup()
         self.shutdown_event.set()
         with self.config_cv:

--- a/app/process_manager.py
+++ b/app/process_manager.py
@@ -21,18 +21,12 @@ class ProcessManager:
             raise ValueError("NEON_PROJECT_ID environment variable is required")
             
         self.branch_id = os.getenv("BRANCH_ID")
-        if not self.branch_id:
-            print("Warning: BRANCH_ID not set, will use parent branch flow")
             
         self.parent_branch_id = os.getenv("PARENT_BRANCH_ID")
-        if not self.parent_branch_id:
-            print("Warning: PARENT_BRANCH_ID not set")
             
         self.delete_branch = os.getenv("DELETE_BRANCH", "true").lower() == "true"
         self.vscode = os.getenv("VSCODE", "").lower() == "true"
         
-        print(f"Debug: Initialized with project_id={self.project_id}, branch_id={self.branch_id}, parent_branch_id={self.parent_branch_id}")
-
     def calculate_file_hash(self, path):
         if not os.path.exists(path):
             return None
@@ -105,10 +99,22 @@ class ProcessManager:
     def _write_neon_branch(self, state):
         try:
             os.makedirs("/tmp/.neon_local", exist_ok=True)
+            # Ensure state is properly formatted for each branch
+            for branch, data in state.items():
+                if isinstance(data, dict) and "branch_id" in data:
+                    # Keep the existing branch_id structure
+                    continue
+                elif isinstance(data, list):
+                    # Convert list of connection info to proper state format
+                    if data and isinstance(data[0], dict) and "database" in data[0]:
+                        # Extract branch_id from the first connection info
+                        branch_id = data[0].get("branch_id")
+                        if branch_id:
+                            state[branch] = {"branch_id": branch_id}
             with open("/tmp/.neon_local/.branches", "w") as file:
                 json.dump(state, file)
-        except:
-            print("Failed to write state file.")
+        except Exception as e:
+            print(f"Failed to write state file: {str(e)}")
 
     def start_process(self):
         raise NotImplementedError

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       NEON_API_KEY: ${NEON_API_KEY}
       NEON_PROJECT_ID: ${NEON_PROJECT_ID}
       #PARENT_BRANCH_ID: ${NEON_PARENT_BRANCH_ID}
+      BRANCH_ID: br-dark-bar-a440iizf
       #DELETE_BRANCH: < True | False >
       #DRIVER: < postgres | serverless >
     #volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     environment:
       NEON_API_KEY: ${NEON_API_KEY}
       NEON_PROJECT_ID: ${NEON_PROJECT_ID}
-      #PARENT_BRANCH_ID: ${NEON_PARENT_BRANCH_ID}
-      BRANCH_ID: br-dark-bar-a440iizf
+      PARENT_BRANCH_ID: ${PARENT_BRANCH_ID}
+      #BRANCH_ID: br-dark-bar-a440iizf
       #DELETE_BRANCH: < True | False >
       #DRIVER: < postgres | serverless >
     #volumes:


### PR DESCRIPTION
There was a bug where if a branch was created from a parent with multiple databases the container would error out and not start because the connection info was not returned by the create branch api. I changed the logic to get all databases/owners for the branch in separate api calls and configured multiple databases in the pgbouncer instance. I also enabled the ability to select an existing branch to connect to by providing BRANCH_ID env variable to the container, though this is not being officially released at this time.