### PR TITLE
Make existing branch higher precidence than ephemeral, and use git-branch name as neon-branch name

### DIFF
--- a/app/haproxy/haproxy_manager.py
+++ b/app/haproxy/haproxy_manager.py
@@ -13,7 +13,13 @@ class HAProxyManager(ProcessManager):
     def prepare_config(self):
         params = None
         
-        if self.parent_branch_id:
+        if self.branch_id:
+            try:
+                params = self.neon_api.get_branch_connection_info(self.project_id, self.branch_id)
+            except Exception as e:
+                print(f"Debug: Error getting connection info: {str(e)}")
+                raise
+        elif self.parent_branch_id:
             state = self._get_neon_branch()
             current_branch = self._get_git_branch()
             parent = os.getenv("PARENT_BRANCH_ID")
@@ -21,12 +27,7 @@ class HAProxyManager(ProcessManager):
                 parent = None
             params, updated_state = self.neon_api.fetch_or_create_branch(state, current_branch, parent, self.vscode)
             self._write_neon_branch(updated_state)
-        elif self.branch_id:
-            try:
-                params = self.neon_api.get_branch_connection_info(self.project_id, self.branch_id)
-            except Exception as e:
-                print(f"Debug: Error getting connection info: {str(e)}")
-                raise
+
         else:
             state = self._get_neon_branch()
             current_branch = self._get_git_branch()

--- a/app/neon.py
+++ b/app/neon.py
@@ -173,11 +173,19 @@ class NeonAPI:
 
         if branch_id is None:
             # Create new branch
-            if parent_branch_id:
-                payload = {"annotation_value": {"neon_local": "true"}, "endpoints": [{"type": "read_write"}], "branch": {"parent_id": parent_branch_id}}
-            else:
-                payload = {"annotation_value": {"neon_local": "true"}, "endpoints": [{"type": "read_write"}]}
+            payload = {
+                "annotation_value": {"neon_local": "true"},
+                "endpoints": [{"type": "read_write"}]
+            }
+
+            if parent_branch_id or current_branch:
+                payload["branch"] = {}
+                if parent_branch_id:
+                    payload["branch"]["parent_id"] = parent_branch_id
+                if current_branch:
+                    payload["branch"]["name"] = current_branch
             if vscode:
+                payload["annotation_value"] = {}
                 payload["annotation_value"]["vscode"] = "true"
             response = requests.post(f"{API_URL}/projects/{self.project_id}/branches",
                                      headers=self._headers(), json=payload)

--- a/app/pgbouncer/pgbouncer_manager.py
+++ b/app/pgbouncer/pgbouncer_manager.py
@@ -49,7 +49,13 @@ class PgBouncerManager(ProcessManager):
         self._generate_certificates()
         params = None
         
-        if self.parent_branch_id:
+        if self.branch_id:
+            try:
+                params = self.neon_api.get_branch_connection_info(self.project_id, self.branch_id)
+            except Exception as e:
+                print(f"Debug: Error getting connection info: {str(e)}")
+                raise
+        elif self.parent_branch_id:
             state = self._get_neon_branch()
             current_branch = self._get_git_branch()
             parent = os.getenv("PARENT_BRANCH_ID")
@@ -57,12 +63,7 @@ class PgBouncerManager(ProcessManager):
                 parent = None
             params, updated_state = self.neon_api.fetch_or_create_branch(state, current_branch, parent, self.vscode)
             self._write_neon_branch(updated_state)
-        elif self.branch_id:
-            try:
-                params = self.neon_api.get_branch_connection_info(self.project_id, self.branch_id)
-            except Exception as e:
-                print(f"Debug: Error getting connection info: {str(e)}")
-                raise
+
         else:
             state = self._get_neon_branch()
             current_branch = self._get_git_branch()


### PR DESCRIPTION
Changed the precedence order between the BRANCH_ID and PARENT_BRANCH_ID env variables so that BRANCH_ID is takes precedence over PARENT_BRANCH_ID so that if both are provided by the user no new neon branch will be created and the proxy routing will configured for the branch provided in the BRANCH_ID env variable.

I also changed it so that if the container has a git volume and can detect the project's git branch name it will use that name as the neon branch name during creation (and increment the name with a _2, _3, _4, postfix if a naming collision occurs).