### PR TITLE
Proof of concept: wsproxy directing WebSocket traffic via pgbouncer

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -3,6 +3,7 @@ FROM envoyproxy/envoy:v1.28-latest AS envoy-source
 
 # Minimal Ubuntu 20.04 base (same version as Envoy, but without all the extras)
 FROM ubuntu:20.04
+ARG TARGETARCH
 
 USER root
 
@@ -27,6 +28,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libc-ares-dev \
     wget \
     && rm -rf /var/lib/apt/lists/*
+
+# get Go and build wsproxy
+RUN wget https://go.dev/dl/go1.25.1.linux-${TARGETARCH}.tar.gz -O /tmp/go.tar.gz \
+  && cd /tmp && tar -C /usr/local -xzf go.tar.gz \
+  && GOBIN=/usr/local/bin /usr/local/go/bin/go install github.com/neondatabase/wsproxy@latest
 
 # Copy Envoy binary from official image (avoid downloading/extracting)
 COPY --from=envoy-source /usr/local/bin/envoy /usr/local/bin/envoy

--- a/app/pgbouncer/pgbouncer.ini.tmpl
+++ b/app/pgbouncer/pgbouncer.ini.tmpl
@@ -17,7 +17,7 @@ min_pool_size = 0
 reserve_pool_size = 5
 
 # SSL configuration
-client_tls_sslmode = require
+client_tls_sslmode = prefer
 client_tls_cert_file = /etc/pgbouncer/server.crt
 client_tls_key_file = /etc/pgbouncer/server.key
 server_tls_sslmode = verify-full

--- a/app/unified_manager.py
+++ b/app/unified_manager.py
@@ -112,6 +112,14 @@ class UnifiedManager(ProcessManager):
             except Exception as e:
                 print(f"Failed to update /etc/hosts at runtime: {e}")
                 
+        print("Starting wsproxy...")
+        wsproxy_env = os.environ.copy()
+        wsproxy_env['LISTEN_PORT'] = ':4433'
+        wsproxy_env['ALLOW_ADDR_REGEX'] = '.*'
+        self.envoy_process = subprocess.Popen([
+          "/usr/local/bin/wsproxy"
+        ], env=wsproxy_env)
+
         # Start PgBouncer first (on internal port 6432)
         print("Starting PgBouncer...")
         


### PR DESCRIPTION
To try this out:

```bash
docker build --tag gmneonlocal ./app

docker run \
  --name db \
  -p 5432:5432 -p 4433:4433 \ 
  -e NEON_API_KEY=<API_KEY> \
  -e NEON_PROJECT_ID=twilight-lake-13291575 \
  -e PARENT_BRANCH_ID=br-withered-tree-a8yhsvyw \
  --rm gmneonlocal
```

And paste this in the Node REPL:

```javascript
neon = require('@neondatabase/serverless')
neon.neonConfig.useSecureWebSocket = neon.neonConfig.pipelineConnect = false
neon.neonConfig.wsProxy = (host, port) => `localhost:4433/v1?address=${host}:${port}`

p = new neon.Pool({ connectionString: 'postgresql://neon:npg@localhost/neondb' })
p.query('SELECT now()').then(res => console.log(res)).catch(e => console.log(e.message))
```